### PR TITLE
Hide overlays if present when changing options in runtime

### DIFF
--- a/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
+++ b/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import UIKit
-import TouchInspector
 
 class ViewController: UIViewController {
     
@@ -31,11 +30,8 @@ class SheetView: UIView {
         
         backgroundColor = .systemGray5
         
-        buildTouchIndicatorButton(maxWidth)
-        buildHitTestingButton(maxWidth)
-        
-        var yOffset: CGFloat = 146
-        for i in 2...15 {
+        var yOffset: CGFloat = 50.0
+        for i in 0...15 {
             let randomWidth = CGFloat(Int.random(in: 40...Int(maxWidth)))
             
             let placeholder = PlaceholderView(frame: CGRect(x: 30.0, y: yOffset, width: randomWidth, height: 32))
@@ -48,38 +44,6 @@ class SheetView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func buildTouchIndicatorButton(_ maxWidth: CGFloat) {
-        let randomWidth = CGFloat(Int.random(in: 180...Int(maxWidth)))
-        let touchesButton = ButtonView(frame: CGRect(x: 30.0, y: 50, width: randomWidth, height: 32),
-                                       title: "Toggle Touches",
-                                       // default is true because window?.windowScene?.delegate is nil ATM
-                                       status: true) {
-            guard let sceneDelegate = self.window?.windowScene?.delegate as? SceneDelegate,
-                  let window = sceneDelegate.window as? TouchInspectorWindow else {
-                return false
-            }
-            window.showTouches = !window.showTouches
-            return window.showTouches
-        }
-        addSubview(touchesButton)
-    }
-    
-    private func buildHitTestingButton(_ maxWidth: CGFloat) {
-        let randomWidth = CGFloat(Int.random(in: 230...Int(maxWidth)))
-        let hitTestingButton = ButtonView(frame: CGRect(x: 30.0, y: 98, width: randomWidth, height: 32),
-                                          title: "Toggle Hit Testing",
-                                          // default is true because window?.windowScene?.delegate is nil ATM
-                                          status: true) {
-            guard let sceneDelegate = self.window?.windowScene?.delegate as? SceneDelegate,
-                  let window = sceneDelegate.window as? TouchInspectorWindow else {
-                return false
-            }
-            window.showHitTesting = !window.showHitTesting
-            return window.showHitTesting
-        }
-        addSubview(hitTestingButton)
     }
 }
 
@@ -96,50 +60,5 @@ class PlaceholderView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-class ButtonView: PlaceholderView {
-    private var buttonAction: () -> Bool
-    private var statusLabel: UILabel!
-    
-    init(frame: CGRect, title: String, status: Bool, action: @escaping () -> Bool) {
-        buttonAction = action
-        super.init(frame: frame)
-        
-        let button = UIButton()
-        button.setTitle(title, for: .normal)
-        button.addTarget(self, action: #selector(buttonPressed(_:)), for: .touchUpInside)
-        addSubview(button)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        button.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30).isActive = true
-        button.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        
-        statusLabel = UILabel()
-        statusLabel.text = status ? "✅" : "❌"
-        statusLabel.textAlignment = .center
-        addSubview(statusLabel)
-        statusLabel.translatesAutoresizingMaskIntoConstraints = false
-        statusLabel.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        statusLabel.leadingAnchor.constraint(equalTo: button.trailingAnchor).isActive = true
-        statusLabel.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        statusLabel.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    @objc
-    private func buttonPressed(_ sender: UIControl) {
-        let newStatus = buttonAction()
-        
-        if newStatus {
-            statusLabel.text = "✅"
-        } else {
-            statusLabel.text = "❌"
-        }
     }
 }

--- a/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
+++ b/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import TouchInspector
 
 class ViewController: UIViewController {
     
@@ -30,8 +31,11 @@ class SheetView: UIView {
         
         backgroundColor = .systemGray5
         
-        var yOffset: CGFloat = 50.0
-        for i in 0...15 {
+        buildTouchIndicatorButton(maxWidth)
+        buildHitTestingButton(maxWidth)
+        
+        var yOffset: CGFloat = 146
+        for i in 2...15 {
             let randomWidth = CGFloat(Int.random(in: 40...Int(maxWidth)))
             
             let placeholder = PlaceholderView(frame: CGRect(x: 30.0, y: yOffset, width: randomWidth, height: 32))
@@ -44,6 +48,38 @@ class SheetView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func buildTouchIndicatorButton(_ maxWidth: CGFloat) {
+        let randomWidth = CGFloat(Int.random(in: 180...Int(maxWidth)))
+        let touchesButton = ButtonView(frame: CGRect(x: 30.0, y: 50, width: randomWidth, height: 32),
+                                       title: "Toggle Touches",
+                                       // default is true because window?.windowScene?.delegate is nil ATM
+                                       status: true) {
+            guard let sceneDelegate = self.window?.windowScene?.delegate as? SceneDelegate,
+                  let window = sceneDelegate.window as? TouchInspectorWindow else {
+                return false
+            }
+            window.showTouches = !window.showTouches
+            return window.showTouches
+        }
+        addSubview(touchesButton)
+    }
+    
+    private func buildHitTestingButton(_ maxWidth: CGFloat) {
+        let randomWidth = CGFloat(Int.random(in: 230...Int(maxWidth)))
+        let hitTestingButton = ButtonView(frame: CGRect(x: 30.0, y: 98, width: randomWidth, height: 32),
+                                          title: "Toggle Hit Testing",
+                                          // default is true because window?.windowScene?.delegate is nil ATM
+                                          status: true) {
+            guard let sceneDelegate = self.window?.windowScene?.delegate as? SceneDelegate,
+                  let window = sceneDelegate.window as? TouchInspectorWindow else {
+                return false
+            }
+            window.showHitTesting = !window.showHitTesting
+            return window.showHitTesting
+        }
+        addSubview(hitTestingButton)
     }
 }
 
@@ -60,5 +96,50 @@ class PlaceholderView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class ButtonView: PlaceholderView {
+    private var buttonAction: () -> Bool
+    private var statusLabel: UILabel!
+    
+    init(frame: CGRect, title: String, status: Bool, action: @escaping () -> Bool) {
+        buttonAction = action
+        super.init(frame: frame)
+        
+        let button = UIButton()
+        button.setTitle(title, for: .normal)
+        button.addTarget(self, action: #selector(buttonPressed(_:)), for: .touchUpInside)
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        button.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30).isActive = true
+        button.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        
+        statusLabel = UILabel()
+        statusLabel.text = status ? "✅" : "❌"
+        statusLabel.textAlignment = .center
+        addSubview(statusLabel)
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        statusLabel.leadingAnchor.constraint(equalTo: button.trailingAnchor).isActive = true
+        statusLabel.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        statusLabel.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc
+    private func buttonPressed(_ sender: UIControl) {
+        let newStatus = buttonAction()
+        
+        if newStatus {
+            statusLabel.text = "✅"
+        } else {
+            statusLabel.text = "❌"
+        }
     }
 }

--- a/Sources/TouchInspector/TouchInspectorWindow.swift
+++ b/Sources/TouchInspector/TouchInspectorWindow.swift
@@ -17,12 +17,20 @@ public class TouchInspectorWindow: UIWindow {
     /**
      Whether to show the circular touch indicator.
      */
-    public var showTouches: Bool = true
+    public var showTouches: Bool = true {
+        didSet {
+            hideOverlaysIfNeeded()
+        }
+    }
     
     /**
      Whether to show the hit-test debugging overlay. If enabled, touch indicators will also be shown.
      */
-    public var showHitTesting: Bool = true
+    public var showHitTesting: Bool = true {
+        didSet {
+            hideOverlaysIfNeeded()
+        }
+    }
     
     private var touchOverlays: [UITouch : TouchOverlayView] = [:]
     
@@ -117,5 +125,19 @@ public class TouchInspectorWindow: UIWindow {
 
         Hit-Test: \(hitTestedView?.description ?? "nil")
         """
+    }
+    
+    private func hideOverlaysIfNeeded() {
+        if !showTouches && !showHitTesting {
+            touchOverlays.values.forEach { overlay in
+                overlay.removeFromSuperview()
+            }
+            touchOverlays = [:]
+        } else if showTouches {
+            touchOverlays.values.forEach { overlay in
+                overlay.hitTestingOverlay.isHidden = !showHitTesting
+            }
+        }
+        
     }
 }


### PR DESCRIPTION
## Changes
- Added buttons on the Demo app to toggle options:
![Simulator Screen Shot - iPhone 13 - 2022-05-12 at 22 08 10](https://user-images.githubusercontent.com/860036/168191482-349946ae-22ee-43bd-8a45-93864a8c0b88.png)

- Make sure to hide all active overlays when toggling options