### PR TITLE
Fix Incorrect Name on Example Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options conn
     window = UIWindow(windowScene: windowScene)
     #endif
     
-    window?.rootViewController = initialViewController
+    window?.rootViewController = rootViewController
     window?.makeKeyAndVisible()
 }
 ```


### PR DESCRIPTION
Somehow I accomplished messing up a two-line PR (#2). 🤦 

When I was originally revamping the README, I was using `initialViewController` as the example variable name, but then changed it to `rootViewController`... in only one of two places. 

This fixes that.