### PR TITLE
Support customizing the touch indicator appearance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "TouchInspector", targets: ["TouchInspector"]),
+            name: "TouchInspector", targets: ["TouchInspector"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,6 +20,6 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(name: "TouchInspector", dependencies: []),
-        .testTarget(name: "TouchInspectorTests", dependencies: ["TouchInspector"]),
+        .testTarget(name: "TouchInspectorTests", dependencies: ["TouchInspector"])
     ]
 )

--- a/Sample App/TouchInspector-Sample/TouchInspector-Sample/AppDelegate.swift
+++ b/Sample App/TouchInspector-Sample/TouchInspector-Sample/AppDelegate.swift
@@ -24,4 +24,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/Sample App/TouchInspector-Sample/TouchInspector-Sample/SceneDelegate.swift
+++ b/Sample App/TouchInspector-Sample/TouchInspector-Sample/SceneDelegate.swift
@@ -11,7 +11,7 @@ import TouchInspector
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -19,20 +19,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else {
             return
         }
-        
+
         #if DEBUG
         window = TouchInspectorWindow(windowScene: windowScene)
         if let window = window as? TouchInspectorWindow {
             window.showTouches = true
-            window.showHitTesting = true
+            window.showHitTesting = false
+
+            // Optional style customization
+//            window.touchStyle = TouchStyle(
+//                material: .color(.white.withAlphaComponent(0.6)),
+//                size: CGSize(width: 50, height: 50),
+//                border: TouchStyle.Border(color: .systemBlue, width: 3)
+//            )
         }
         #else
         window = UIWindow(windowScene: windowScene)
         #endif
-        
+
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
     }
 
 }
-

--- a/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
+++ b/Sample App/TouchInspector-Sample/TouchInspector-Sample/ViewController.swift
@@ -9,14 +9,13 @@ import Foundation
 import UIKit
 
 class ViewController: UIViewController {
-    
-    var sheetView: SheetView!
-    
+
+    lazy var sheetView = SheetView(maxWidth: view.bounds.size.width * 0.7)
+
     override func viewDidLoad() {
-        sheetView = SheetView(maxWidth: view.bounds.size.width * 0.7)
         view.addSubview(sheetView)
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         sheetView.frame = view.bounds
@@ -24,24 +23,24 @@ class ViewController: UIViewController {
 }
 
 class SheetView: UIView {
-    
+
     init(maxWidth: CGFloat) {
         super.init(frame: .zero)
-        
+
         backgroundColor = .systemGray5
-        
+
         var yOffset: CGFloat = 50.0
         for i in 0...15 {
             let randomWidth = CGFloat(Int.random(in: 40...Int(maxWidth)))
-            
+
             let placeholder = PlaceholderView(frame: CGRect(x: 30.0, y: yOffset, width: randomWidth, height: 32))
             addSubview(placeholder)
-            
+
             let sectionBreak = (i + 1) % 3 == 0 ? 40.0 : 0.0
             yOffset += (placeholder.bounds.size.height * 1.5 + sectionBreak)
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -50,14 +49,14 @@ class SheetView: UIView {
 class PlaceholderView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         let colors: [UIColor] = [.systemRed, .systemYellow, .systemOrange, .systemPink, .systemPurple, .systemBlue]
         backgroundColor = colors.randomElement()?.withAlphaComponent(0.5)
-    
+
         layer.cornerRadius = 8
         layer.cornerCurve = .continuous
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/TouchInspector/TouchInspectorWindow.swift
+++ b/Sources/TouchInspector/TouchInspectorWindow.swift
@@ -12,70 +12,136 @@
 import Foundation
 import UIKit
 
+public struct TouchStyle: Equatable {
+
+    public static var blueBordered = TouchStyle(
+        material: .color(.systemBlue.withAlphaComponent(0.6)),
+        size: CGSize(width: 48, height: 48),
+        border: TouchStyle.Border(color: .systemBlue, width: 3)
+    )
+
+    public static var materialDot = TouchStyle(
+        material: .materialBlur,
+        size: CGSize(width: 32, height: 32),
+        border: nil
+    )
+
+    public enum Material: Equatable {
+        case materialBlur
+        case color(UIColor)
+
+        var blurEffect: UIBlurEffect? {
+            switch self {
+            case .materialBlur:
+                return UIBlurEffect(style: .systemThinMaterialDark)
+            default:
+                return nil
+            }
+        }
+
+        var backgroundColor: UIColor? {
+            switch self {
+            case .materialBlur:
+                return nil
+            case .color(let color):
+                return color
+            }
+        }
+    }
+
+    public struct Border: Equatable {
+        let color: UIColor
+        let width: CGFloat
+
+        public init(color: UIColor, width: CGFloat) {
+            self.color = color
+            self.width = width
+        }
+    }
+
+    let material: Material
+    let size: CGSize
+    let border: Border?
+
+    public init(
+        material: Material,
+        size: CGSize,
+        border: Border? = nil) {
+        self.material = material
+        self.size = size
+        self.border = border
+    }
+}
+
 public class TouchInspectorWindow: UIWindow {
-    
+
     /**
      Whether to show the circular touch indicator.
      */
     public var showTouches: Bool = true
-    
+
     /**
      Whether to show the hit-test debugging overlay. If enabled, touch indicators will also be shown.
      */
     public var showHitTesting: Bool = true
-    
-    private var touchOverlays: [UITouch : TouchOverlayView] = [:]
-    
+
+    /**
+     The visual style of the touch indicator view. Configurable by creating a custom `TouchStyle`.
+     */
+    public var touchStyle = TouchStyle.blueBordered
+
+    private var touchOverlays: [UITouch: TouchOverlayView] = [:]
+
     public override init(windowScene: UIWindowScene) {
         super.init(windowScene: windowScene)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Event Handling
-    
+
     public override func sendEvent(_ event: UIEvent) {
         handleTouchesEvent(event)
         super.sendEvent(event)
     }
-    
+
     // MARK: - Private
-    
+
     private func handleTouchesEvent(_ touchesEvent: UIEvent) {
         guard showTouches || showHitTesting else {
             return
         }
-        
+
         guard touchesEvent.type == .touches else {
             return
         }
-        
+
         for touch in touchesEvent.allTouches ?? [] {
             let touchLocationInWindow = touch.location(in: self)
             let touchPhase = touch.phase
-            
+
             if touchPhase == .began {
-                createTouchOverlay(for: touch)
+                createTouchOverlay(for: touch, with: touchStyle)
             }
-            
+
             updateTouchOverlay(
                 for: touch,
                 location: touchLocationInWindow,
                 hitTestedView: hitTest(touchLocationInWindow, with: touchesEvent)
             )
-            
+
             if touchPhase == .ended || touchPhase == .cancelled {
                 removeTouchOverlay(for: touch)
             }
         }
     }
-    
-    private func createTouchOverlay(for touch: UITouch) {
-        let overlay = TouchOverlayView()
+
+    private func createTouchOverlay(for touch: UITouch, with style: TouchStyle) {
+        let overlay = TouchOverlayView(style: style)
         touchOverlays[touch] = overlay
-        
+
         addSubview(overlay)
         overlay.present()
     }
@@ -84,33 +150,45 @@ public class TouchInspectorWindow: UIWindow {
         guard let overlay = touchOverlays[touch] else {
             return
         }
-        
+
         overlay.hitTestingOverlay.text = hitTestOverlayDescription(for: location, hitTestedView: hitTestedView)
         overlay.hitTestingOverlay.isHidden = !showHitTesting
-        
-        overlay.frame.origin = location
-        overlay.setNeedsLayout()
-        
+
+        if overlay.frame == .zero {
+            overlay.frame.origin = location
+            overlay.setNeedsLayout()
+        }
+
+        if #available(iOS 17.0, *) {
+            UIView.animate(springDuration: 0.1, bounce: 0.1) {
+                overlay.frame.origin = location
+                overlay.setNeedsLayout()
+            }
+        } else {
+            overlay.frame.origin = location
+            overlay.setNeedsLayout()
+        }
+
         bringSubviewToFront(overlay)
     }
-    
+
     private func removeTouchOverlay(for touch: UITouch) {
         guard let overlay = touchOverlays[touch] else {
             return
         }
-        
+
         overlay.hide(completion: {
             overlay.removeFromSuperview()
             self.touchOverlays.removeValue(forKey: touch)
         })
     }
-    
+
     private func hitTestOverlayDescription(for locationInWindow: CGPoint, hitTestedView: UIView?) -> String {
         let locationInWindowDescription = locationInWindow.shortDescription
-        
+
         let locationInHitTestedView = self.convert(locationInWindow, to: hitTestedView)
         let locationInHitTestedViewDescription = locationInHitTestedView.shortDescription
-        
+
         return """
         Touch:   \(locationInWindowDescription)
         In View: \(locationInHitTestedViewDescription)

--- a/Sources/TouchInspector/TouchOverlayView.swift
+++ b/Sources/TouchInspector/TouchOverlayView.swift
@@ -13,110 +13,116 @@ import Foundation
 import UIKit
 
 class TouchOverlayView: UIView {
-    
-    let touchIndicatorView = TouchIndicatorView(size: CGSize(width: 30, height: 30))
-    let hitTestingOverlay = HitTestingOverlay()
-    
+
+    lazy var touchIndicatorView = TouchIndicatorView(style: touchStyle)
+
+    lazy var hitTestingOverlay = HitTestingOverlay()
+
     class TouchIndicatorView: UIVisualEffectView {
-    
+
         let blurEffect = UIBlurEffect(style: .systemThinMaterialDark)
-        
-        init(size: CGSize) {
-            super.init(effect: blurEffect)
-            
-            bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-            backgroundColor = .white.withAlphaComponent(0.5)
-            
+
+        init(style: TouchStyle) {
+            super.init(effect: style.material.blurEffect)
+
+            bounds = CGRect(x: 0, y: 0, width: style.size.width, height: style.size.height)
+            backgroundColor = style.material.backgroundColor
+            layer.borderWidth = style.border?.width ?? 0
+            layer.borderColor = style.border?.color.cgColor ?? nil
+
             layer.cornerRadius = bounds.size.height / 2.0
             layer.masksToBounds = true
         }
-        
+
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
     }
-    
+
     class HitTestingOverlay: UIView {
-        
+
         let blurEffect = UIBlurEffect(style: .systemThinMaterialDark)
         lazy var blurVisualEffectView = UIVisualEffectView(effect: blurEffect)
         lazy var vibrancyEffectView = UIVisualEffectView(effect: UIVibrancyEffect(blurEffect: blurEffect, style: .label))
-        
+
         let margin: CGFloat = 10
         let maxWidth: CGFloat = 220
         let maxHeight: CGFloat = 1000
-        
+
         private let textView: UILabel = {
             let textView = UILabel()
             textView.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
             textView.numberOfLines = 0
             return textView
         }()
-        
+
         init() {
             super.init(frame: .zero)
-            
+
             addSubview(blurVisualEffectView)
             blurVisualEffectView.contentView.addSubview(vibrancyEffectView)
             vibrancyEffectView.contentView.addSubview(textView)
-            
+
             layer.cornerRadius = 12
             layer.cornerCurve = .continuous
             layer.masksToBounds = true
         }
-        
+
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-        
+
         var text: String? {
             didSet {
                 textView.text = text
             }
         }
-        
+
         override var intrinsicContentSize: CGSize {
             let size = textView.sizeThatFits(CGSize(width: maxWidth, height: maxHeight))
             return CGSize(width: size.width + margin * 2, height: size.height + margin * 2)
         }
-        
+
         override func layoutSubviews() {
             super.layoutSubviews()
-            
+
             blurVisualEffectView.frame = bounds
             vibrancyEffectView.frame = blurVisualEffectView.bounds
             textView.frame = vibrancyEffectView.contentView.bounds
-            
+
             textView.frame.size = CGSize(width: bounds.size.width - (margin * 2), height: bounds.size.height - (margin * 2))
             textView.frame.origin = CGPoint(x: margin, y: margin)
         }
     }
-    
-    init() {
+
+    let touchStyle: TouchStyle
+
+    init(style: TouchStyle) {
+        self.touchStyle = style
         super.init(frame: .zero)
-        
+
         addSubview(touchIndicatorView)
         addSubview(hitTestingOverlay)
-        
+
         isUserInteractionEnabled = false
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Presentation
-    
+
     func present() {
         alpha = 0
         touchIndicatorView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
-        
+
         animateBlock {
             self.alpha = 1
             self.touchIndicatorView.transform = .identity
         }
     }
-    
+
     func hide(completion: @escaping (() -> Void)) {
         animateBlock {
             self.alpha = 0
@@ -125,47 +131,47 @@ class TouchOverlayView: UIView {
             completion()
         }
     }
-    
+
     // MARK: - Hit Testing
-    
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         nil
     }
-    
+
     // MARK: - Layout
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         guard let superview = superview else {
             return
         }
-        
+
         // Touch Indicator
         touchIndicatorView.center = bounds.origin
-        
+
         // Hit Test Overlay
         let labelIntrinsicContentSize = hitTestingOverlay.intrinsicContentSize
-        
+
         let touchLocation = frame.origin
         let screenWidth = superview.bounds.size.width
-        
+
         let labelWidth = labelIntrinsicContentSize.width
-        
+
         let yPadding: CGFloat = 40
-        
+
         var x: CGFloat = 0
         var y: CGFloat = yPadding
-        
+
         if touchLocation.x + labelWidth > screenWidth {
             x = -labelIntrinsicContentSize.width
         }
-        
+
         if (touchLocation.y + labelIntrinsicContentSize.height + yPadding) > superview.bounds.size.height {
             y = -labelIntrinsicContentSize.height - yPadding
         }
-        
+
         hitTestingOverlay.frame = CGRect(x: x, y: y, width: labelIntrinsicContentSize.width, height: labelIntrinsicContentSize.height)
     }
-    
+
 }

--- a/Sources/TouchInspector/Utilities.swift
+++ b/Sources/TouchInspector/Utilities.swift
@@ -26,4 +26,3 @@ func animateBlock(_ block: @escaping (() -> Void), completion: (() -> Void)? = n
     }
 
 }
-

--- a/Tests/TouchInspectorTests/TouchInspectorTests.swift
+++ b/Tests/TouchInspectorTests/TouchInspectorTests.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import TouchInspector
 
 final class TouchInspectorTests: XCTestCase {
-    
+
 }


### PR DESCRIPTION
You can now customize the visual appearance of the touch indicator dot via:

```swift
window.touchStyle = TouchStyle(
  material: .color(.white.withAlphaComponent(0.6)),
  size: CGSize(width: 50, height: 50),
  border: TouchStyle.Border(color: .systemBlue, width: 4)
)
```